### PR TITLE
Reduce security problems by deleting challenge ingress when it is not…

### DIFF
--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -2,6 +2,7 @@
 using KCert.Services;
 using Microsoft.AspNetCore.Mvc;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace KCert.Controllers;
@@ -73,7 +74,7 @@ public class HomeController : Controller
         var cert = _cert.GetCert(secret);
         var hosts = _cert.GetHosts(cert).ToArray();
 
-        await _kcert.StartRenewalProcessAsync(ns, name, hosts);
+        await _kcert.StartRenewalProcessAsync(ns, name, hosts, CancellationToken.None);
         return RedirectToAction("Home");
     }
 

--- a/Controllers/HttpChallengeController.cs
+++ b/Controllers/HttpChallengeController.cs
@@ -16,16 +16,16 @@ public class HttpChallengeController : ControllerBase
         _cert = cert;
     }
 
-    [HttpGet("{key}")]
-    public IActionResult GetChallengeResults(string key)
+    [HttpGet("{token}")]
+    public IActionResult GetChallengeResults(string token)
     {
-        _log.LogInformation("Received ACME Challenge: {key}", key);
-        var thumb = _cert.GetThumbprint(key);
+        _log.LogInformation("Received ACME Challenge: {token}", token);
+        var thumb = _cert.GetThumbprint(token);
         if (thumb == null)
         {
             return NotFound();
         }
 
-        return Ok($"{key}.{thumb}");
+        return Ok($"{token}.{thumb}");
     }
 }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 KCert is a simple alternative to [cert-manager](https://github.com/jetstack/cert-manager):
 
-- Deploys with less than 150 lines (vs. 26000 lines of yaml for cert-manager)
+- Deploys with around 100 lines of yaml (vs. thousands of lines for [cert-manager](https://cert-manager.io/docs/installation/))
 - Does not create or need any CRDs (Custom Resource Definitions) to operate
 - Runs a single service in your cluster, isolated in its own namespace
 

--- a/README.md
+++ b/README.md
@@ -2,23 +2,35 @@
 
 KCert is a simple alternative to [cert-manager](https://github.com/jetstack/cert-manager):
 
-- Instead of 26000 lines of yaml, `KCert` deploys with less than 150 lines
-- Instead of custom resources, `KCert` uses the existing standard Kubernetes objects
-- The codebase is small and easy to understand
+- Deploys with less than 150 lines (vs. 26000 lines of yaml for cert-manager)
+- Does not create or need any CRDs (Custom Resource Definitions) to operate
+- Runs a single service in your cluster, isolated in its own namespace
+
+## How it Works
+
+- KCert runs as a single-replica deployment in your cluster
+- An ingress is managed to route `.acme/challenge` requests to the service
+- Service provides a web UI for basic information and configuration details
+- Checks for certificates needing renewal every 6 hours
+- Automatically renews certificates with less than 30 days of validity
+- Watches for created and updated ingresses in the cluster
+- Automatically creates certificates for ingresses with the `kcert.dev/kcert=managed` label
 
 ## Installing KCert
 
-The following instructions assume that you will be using the included `deploy.yml` file as your template for install KCert.
+The following instructions assume that you will be using the included `deploy.yml` file as your template to install KCert.
 If you are customizing your setup you will likely need to modify the following instructions accordingly.
 
 Below you can find more details, but setting up KCert involves the following steps:
 
 - Create SMTP credentials for KCert to send automatic email notifications (or skip SMTP related instructions)
-- Generate a ECDSA key by running `docker run -it nabsul/kcert:1.0.0 dotnet KCert.dll generate-key`
+- Generate an ECDSA key by running `docker run -it nabsul/kcert:v1.0.0 dotnet KCert.dll generate-key`
 - Create the KCert namespace with `kubectl create namespace kcert`
-- Create the KCert secret with `kubectl -n kcert create secret generic kcert --from-literal=acme=[...] --from-literal=smtp=[...]`
+- Create a secret with `kubectl -n kcert create secret generic kcert --from-literal=acme=[...] --from-literal=smtp=[...]`
 - Fill in the `deploy.yml` file and run `kubectl apply -f deploy.yml`
 - Start `kubectl -n kcert port-forward svc/kcert 80` and view the dashboard at `http://localhost`
+
+The following sections describe the above in more detail.
 
 ### Create KCert secrets
 
@@ -53,21 +65,6 @@ To check that everything is running as expected:
 
 - Run `kubectl -n kcert logs svc/kcert` and make sure there are no error messages
 - Run `kubectl -n kcert port-forward svc/kcert 80` and go to `http://localhost:80` in your browser
-
-## Uninstalling KCert
-
-KCert does not create many resources,
-and most of them are restricted to the kcert namespace.
-Removing KCert from your cluster is as simple as executing these three commands:
-
-```sh
-kubectl delete namespace kcert
-kubectl delete clusterrolebinding kcert
-kubectl delete clusterrole kcert
-```
-
-Note that certificates created by KCert in other namespaces will NOT be deleted.
-You can keep those certificates or manually delete them.
 
 ## Creating Certificates
 
@@ -176,22 +173,28 @@ with a `ACME__RENEWALCHECKTIMEHOURS` environment variable.
 Note that there are two underscore (`_`) characters in between the two parts of the setting name.
 For more information see the [official .NET Core documentation](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-6.0).
 
-## How it Works
-
-- An ingress definition routes `.acme/challenge` requests to KCert for HTTP challenge requests
-- Service provides a web UI and to manually manage and certs
-- KCert will automatically check for certificates needing renewal every 6 hours
-- KCert will renew a certificate if it expires in less than 30 days
-- KCert watches for created and updated ingresses in the cluster
-- KCert will automatically create and manage certificates for ingresses with the `kcert.dev/kcert=managed` label
-
 ## Building from Scratch
 
 To build your own container image: `docker build -t [your tag] .`
 
 ## Running Locally
 
+For local development, I recommend using `dotnet user-secrets` to configure all of KCert's required settings.
 You can run KCert locally with `dotnet run`.
-If you have Kubectl configured to connect to your cluster,
-KCert will use those settings to do the same.
+KCert will use your local kubectl configuration to connect to a Kubernetes cluster.
 It will behave as if it is running in the cluster and you will be able to explore any settings that might be there.
+
+## Uninstalling KCert
+
+KCert does not create many resources,
+and most of them are restricted to the kcert namespace.
+Removing KCert from your cluster is as simple as executing these three commands:
+
+```sh
+kubectl delete namespace kcert
+kubectl delete clusterrolebinding kcert
+kubectl delete clusterrole kcert
+```
+
+Note that certificates created by KCert in other namespaces will NOT be deleted.
+You can keep those certificates or manually delete them.

--- a/Services/CertClient.cs
+++ b/Services/CertClient.cs
@@ -64,25 +64,9 @@ public class CertClient
         var key = sign.ExportECPrivateKey();
         return Base64UrlTextEncoder.Encode(key);
     }
-    public void AddChallengeKey(string key)
-    {
-        if (_cfg.AcceptAllChallenges)
-        {
-            return;
-        }
+    public void AddChallengeToken(string token) => _validKeys.Add(token);
 
-        _validKeys.Add(key);
-    }
-
-    public void RemoveChallengeKey(string key)
-    {
-        if (_cfg.AcceptAllChallenges)
-        {
-            return;
-        }
-
-        _validKeys.Remove(key);
-    }
+    public void ClearChallengeTokens() => _validKeys.Clear();
 
     public string GetThumbprint(string token)
     {

--- a/Services/IngressMonitorService.cs
+++ b/Services/IngressMonitorService.cs
@@ -1,6 +1,5 @@
 ﻿using k8s;
 using k8s.Models;
-using KCert.Models;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System;
@@ -102,21 +101,6 @@ public class IngressMonitorService : IHostedService
             }
         }
 
-        try
-        {
-            if (await _kcert.AddChallengeHostsAsync(hosts))
-            {
-                _log.LogInformation("Giving challenge ingress time to propagate");
-                await Task.Delay(TimeSpan.FromSeconds(10), tok);
-            }
-
-            await _kcert.RenewCertAsync(ns, name, hosts.ToArray());
-            await _kcert.RemoveChallengeHostsAsync(hosts);
-            await _email.NotifyRenewalResultAsync(ns, name, null);
-        }
-        catch (RenewalException ex)
-        {
-            await _email.NotifyRenewalResultAsync(ns, name, ex);
-        }
+        await _kcert.StartRenewalProcessAsync(ns, name, hosts.ToArray());
     }
 }

--- a/Services/K8sClient.cs
+++ b/Services/K8sClient.cs
@@ -182,7 +182,7 @@ public class K8sClient
 
     public async Task CreateIngressAsync(V1Ingress ingress)
     {
-        await _client.CreateNamespacedIngressAsync(ingress, ingress.Name(), ingress.Namespace());
+        await _client.CreateNamespacedIngressAsync(ingress, _cfg.KCertNamespace);
     }
 
     public async Task UpdateTlsSecretAsync(string ns, string name, string key, string cert)

--- a/Services/K8sClient.cs
+++ b/Services/K8sClient.cs
@@ -163,9 +163,26 @@ public class K8sClient
         }
     }
 
-    public async Task UpdateIngressAsync(V1Ingress ingress)
+    public async Task DeleteIngressAsync(string ns, string name)
     {
-        await _client.ReplaceNamespacedIngressAsync(ingress, ingress.Name(), ingress.Namespace());
+        try
+        {
+            await _client.DeleteNamespacedIngressAsync(name, ns);
+        }
+        catch (HttpOperationException ex)
+        {
+            if (ex.Response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return;
+            }
+
+            throw;
+        }
+    }
+
+    public async Task CreateIngressAsync(V1Ingress ingress)
+    {
+        await _client.CreateNamespacedIngressAsync(ingress, ingress.Name(), ingress.Namespace());
     }
 
     public async Task UpdateTlsSecretAsync(string ns, string name, string key, string cert)

--- a/Services/KCertClient.cs
+++ b/Services/KCertClient.cs
@@ -85,7 +85,6 @@ public class KCertClient
             Metadata = new()
             {
                 Name = _cfg.KCertIngressName,
-                NamespaceProperty = _cfg.KCertNamespace,
                 Annotations = _cfg.ChallengeIngressAnnotations,
             },
             Spec = new()

--- a/Services/KCertClient.cs
+++ b/Services/KCertClient.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace KCert.Services;
@@ -85,6 +86,7 @@ public class KCertClient
             Metadata = new()
             {
                 Name = _cfg.KCertIngressName,
+                NamespaceProperty = _cfg.KCertNamespace,
                 Annotations = _cfg.ChallengeIngressAnnotations,
             },
             Spec = new()
@@ -93,6 +95,7 @@ public class KCertClient
             }
         };
 
+        _log.LogInformation(JsonSerializer.Serialize(kcertIngress));
         await _kube.CreateIngressAsync(kcertIngress);
         _log.LogInformation("Giving challenge ingress time to propagate");
         await Task.Delay(TimeSpan.FromSeconds(5));

--- a/Services/KCertClient.cs
+++ b/Services/KCertClient.cs
@@ -1,6 +1,7 @@
 ﻿using k8s.Models;
 using KCert.Models;
 using Microsoft.Extensions.Logging;
+using Microsoft.Rest;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -66,6 +67,11 @@ public class KCertClient
         {
             _log.LogError(ex, "Renewal failed");
             await _email.NotifyRenewalResultAsync(ns, secretName, ex);
+        }
+        catch (HttpOperationException ex)
+        {
+            _log.LogError(ex.Response.Content);
+            throw;
         }
         catch (Exception ex)
         {

--- a/Services/KCertConfig.cs
+++ b/Services/KCertConfig.cs
@@ -21,6 +21,8 @@ public class KCertConfig
     public string KCertIngressName => GetString("KCert:IngressName");
     public int KCertServicePort => GetInt("KCert:ServicePort");
 
+    public string ChallengeIngressAnnotation => GetString("ChallengeIngress:Annotation");
+
     public TimeSpan AcmeWaitTime => TimeSpan.FromSeconds(_cfg.GetValue<int>("Acme:ValidationWaitTimeSeconds"));
     public int AcmeNumRetries => _cfg.GetValue<int>("Acme:ValidationNumRetries");
     public bool EnableAutoRenew => GetBool("Acme:AutoRenewal");

--- a/Services/KCertConfig.cs
+++ b/Services/KCertConfig.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.Extensions.Configuration;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace KCert.Services;
 
@@ -21,7 +23,9 @@ public class KCertConfig
     public string KCertIngressName => GetString("KCert:IngressName");
     public int KCertServicePort => GetInt("KCert:ServicePort");
 
-    public string ChallengeIngressAnnotation => GetString("ChallengeIngress:Annotation");
+    public Dictionary<string, string> ChallengeIngressAnnotations => GetDictionary("ChallengeIngress:Annotations");
+
+    public Dictionary<string, string> ChallengeIngressLabels => GetDictionary("ChallengeIngress:Labels");
 
     public TimeSpan AcmeWaitTime => TimeSpan.FromSeconds(_cfg.GetValue<int>("Acme:ValidationWaitTimeSeconds"));
     public int AcmeNumRetries => _cfg.GetValue<int>("Acme:ValidationNumRetries");
@@ -76,4 +80,10 @@ public class KCertConfig
     private string GetString(string key) => _cfg.GetValue<string>(key);
     private int GetInt(string key) => _cfg.GetValue<int>(key);
     private bool GetBool(string key) => _cfg.GetValue<bool>(key);
+
+    private Dictionary<string, string> GetDictionary(string key)
+    {
+        var data = _cfg.GetSection(key)?.GetChildren() ?? Enumerable.Empty<IConfigurationSection>();
+        return data.ToDictionary(s => s.Key, s => s.Value);
+    }
 }

--- a/Services/RenewalHandler.cs
+++ b/Services/RenewalHandler.cs
@@ -27,6 +27,7 @@ public class RenewalHandler
 
     public async Task RenewCertAsync(string ns, string secretName, string[] hosts)
     {
+        _cert.ClearChallengeTokens();
         _log.Clear();
 
         try
@@ -60,6 +61,10 @@ public class RenewalHandler
                 Logs = _log.Dump(),
             };
         }
+        finally
+        {
+            _cert.ClearChallengeTokens();
+        }
     }
 
     private async Task<(string KID, string Nonce)> InitAsync(string key, Uri acmeDir, string email, bool termsAccepted)
@@ -89,6 +94,7 @@ public class RenewalHandler
 
         var challengeUri = new Uri(auth.Challenges.FirstOrDefault(c => c.Type == "http-01")?.Url);
         var chall = await _acme.TriggerChallengeAsync(key, challengeUri, kid, nonce);
+        _cert.AddChallengeToken(chall.Token);
         nonce = chall.Nonce;
         _log.LogInformation("TriggerChallenge {challengeUri}: {status}", challengeUri, chall.Status);
 

--- a/Services/RenewalService.cs
+++ b/Services/RenewalService.cs
@@ -105,7 +105,7 @@ public class RenewalService : IHostedService
 
         try
         {
-            await _kcert.StartRenewalProcessAsync(secret.Namespace(), secret.Name(), hosts.ToArray());
+            await _kcert.StartRenewalProcessAsync(secret.Namespace(), secret.Name(), hosts.ToArray(), tok);
             await _email.NotifyRenewalResultAsync(secret.Namespace(), secret.Name(), null);
         }
         catch (RenewalException ex)

--- a/Services/RenewalService.cs
+++ b/Services/RenewalService.cs
@@ -105,14 +105,7 @@ public class RenewalService : IHostedService
 
         try
         {
-            if (await _kcert.AddChallengeHostsAsync(hosts))
-            {
-                _log.LogInformation("Giving challenge ingress time to propagate");
-                await Task.Delay(TimeSpan.FromSeconds(10), tok);
-            }
-
-            await _kcert.RenewCertAsync(secret.Namespace(), secret.Name());
-            await _kcert.RemoveChallengeHostsAsync(hosts);
+            await _kcert.StartRenewalProcessAsync(secret.Namespace(), secret.Name(), hosts.ToArray());
             await _email.NotifyRenewalResultAsync(secret.Namespace(), secret.Name(), null);
         }
         catch (RenewalException ex)

--- a/Startup.cs
+++ b/Startup.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Hosting;
 using System;
 using System.Linq;
 using System.Reflection;
+using System.Text.Json;
 
 namespace KCert;
 

--- a/Startup.cs
+++ b/Startup.cs
@@ -2,10 +2,8 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using System;
 using System.Linq;
 using System.Reflection;
-using System.Text.Json;
 
 namespace KCert;
 
@@ -35,7 +33,6 @@ public class Startup
 
     private static void AddKCertServices(IServiceCollection services)
     {
-        Console.WriteLine("Adding KCert services");
         var serviceTypes = Assembly.GetExecutingAssembly().GetTypes()
             .Where(t => t.GetCustomAttribute<ServiceAttribute>() != null);
 

--- a/appsettings.json
+++ b/appsettings.json
@@ -14,5 +14,9 @@
     "RenewalCheckTimeHours": 6,
     "RenewalExpirationRenewalDays": 30,
     "AutoRenewal": true
+  },
+  "ChallengeIngress": {
+    "Annotation": "kubernetes.io/ingress.class:nginx",
+    "Label": null
   }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -16,7 +16,9 @@
     "AutoRenewal": true
   },
   "ChallengeIngress": {
-    "Annotation": "kubernetes.io/ingress.class:nginx",
-    "Label": null
+    "Annotations": {
+      "kubernetes.io/ingress.class": "nginx"
+    },
+    "Labels": null
   }
 }

--- a/deploy.yml
+++ b/deploy.yml
@@ -1,4 +1,9 @@
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: kcert
+---
+apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kcert
@@ -37,8 +42,7 @@ metadata:
 rules:
 - apiGroups: ["networking.k8s.io"]
   resources: ["ingresses"]
-  resourceNames: ["kcert"]
-  verbs: ["get", "create", "delete", "update", "patch"]
+  verbs: ["get", "list", "create", "delete", "update", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -79,34 +83,12 @@ spec:
         - containerPort: 80
           name: http
         env:
-        - name: NAMESPACE
-          value: kcert
-        - name: ENABLEAUTORENEWAL
-          value: "true"
         - name: ACME__DIRURL
-          value: https://acme-v02.api.letsencrypt.org/directory
+          value: # https://acme-staging-v02.api.letsencrypt.org/directory or https://acme-v02.api.letsencrypt.org/directory
         - name: ACME__TERMSACCEPTED
           value: # You must set this to "true" to indicate your acceptance of Let's Encrypt's terms of service (https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf)
         - name: ACME__EMAIL
           value: # Your email address for Let's Encrypt and email notifications
-        - name: ACME__KEY
-          valueFrom:
-            secretKeyRef:
-              name: kcert
-              key: acme
-        - name: SMTP__EMAILFROM
-          value: # The address from which you will send automated emails
-        - name: SMTP__HOST
-          value: SMTP host for email notifications
-        - name: SMTP__PORT
-          value: "587" # Change this if necessary
-        - name: SMTP__USER
-          value: # SMTP user name
-        - name: SMTP__PASS
-          valueFrom:
-            secretKeyRef:
-              name: kcert
-              key: smtp
 ---
 apiVersion: v1
 kind: Service

--- a/deploy.yml
+++ b/deploy.yml
@@ -1,9 +1,4 @@
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: kcert
----
-apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kcert
@@ -43,7 +38,7 @@ rules:
 - apiGroups: ["networking.k8s.io"]
   resources: ["ingresses"]
   resourceNames: ["kcert"]
-  verbs: ["get", "create", "update", "patch"]
+  verbs: ["get", "create", "delete", "update", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -55,7 +50,7 @@ subjects:
   name: kcert
   namespace: kcert
 roleRef:
-  kind: ClusterRole
+  kind: Role
   name: kcert
   apiGroup: rbac.authorization.k8s.io
 ---
@@ -128,23 +123,3 @@ spec:
       targetPort: 80
   selector:
     app: kcert
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: kcert
-  namespace: kcert
-  annotations:
-    kubernetes.io/ingress.class: nginx
-spec:
-  rules:
-  - host: dummy.example.test # needed because we can't have an empty ingress
-    http:
-      paths:
-      - path: /.well-known/acme-challenge
-        pathType: Prefix
-        backend:
-          service:
-            name: kcert
-            port:
-              number: 80


### PR DESCRIPTION
- Create and delete challenge ingress to reduce security risk
- Automatically generate key if it's not provided
- Simplify initial setup instructions by skipping ACME Key and SMTP
- Ensure that only one certificate renewal executes at a time
