### PR TITLE
Make Ingress ClassName, Labels, Annotations Configurable

### DIFF
--- a/Services/KCertClient.cs
+++ b/Services/KCertClient.cs
@@ -95,14 +95,27 @@ public class KCertClient
             {
                 Name = _cfg.KCertIngressName,
                 NamespaceProperty = _cfg.KCertNamespace,
-                Annotations = _cfg.ChallengeIngressAnnotations,
             },
             Spec = new()
             {
-                IngressClassName = _cfg.ChallengeIngressClassName,
                 Rules = hosts.Select(CreateRule).ToList()
             }
         };
+
+        if (_cfg.UseChallengeIngressClassName)
+        {
+            kcertIngress.Spec.IngressClassName = _cfg.ChallengeIngressClassName;
+        }
+
+        if (_cfg.UseChallengeIngressAnnotations)
+        {
+            kcertIngress.Metadata.Annotations = _cfg.ChallengeIngressAnnotations;
+        }
+
+        if (_cfg.UseChallengeIngressLabels)
+        {
+            kcertIngress.Metadata.Labels = _cfg.ChallengeIngressLabels;
+        }
 
         await _kube.CreateIngressAsync(kcertIngress);
         _log.LogInformation("Giving challenge ingress time to propagate");

--- a/Services/KCertConfig.cs
+++ b/Services/KCertConfig.cs
@@ -28,9 +28,13 @@ public class KCertConfig
     public bool ShowRenewButton => GetBool("KCert:ShowRenewButton");
     public int InitialSleepOnFailure => GetInt("KCert:InitialSleepOnFailure");
 
-    public Dictionary<string, string> ChallengeIngressAnnotations => GetDictionary("ChallengeIngress:Annotations");
+    public bool UseChallengeIngressClassName => GetBool("ChallengeIngress:UseClassName");
     public string ChallengeIngressClassName => GetString("ChallengeIngress:ClassName");
 
+    public bool UseChallengeIngressAnnotations => GetBool("ChallengeIngress:UseAnnotations");
+    public Dictionary<string, string> ChallengeIngressAnnotations => GetDictionary("ChallengeIngress:Annotations");
+
+    public bool UseChallengeIngressLabels => GetBool("ChallengeIngress:UseLabels");
     public Dictionary<string, string> ChallengeIngressLabels => GetDictionary("ChallengeIngress:Labels");
 
     public TimeSpan AcmeWaitTime => TimeSpan.FromSeconds(_cfg.GetValue<int>("Acme:ValidationWaitTimeSeconds"));

--- a/appsettings.json
+++ b/appsettings.json
@@ -30,10 +30,13 @@
     "AutoRenewal": true
   },
   "ChallengeIngress": {
+    "UseClassName": true,
     "ClassName": "nginx",
+    "UseAnnotations": false,
     "Annotations": {
       "kubernetes.io/ingress.class": "nginx"
     },
+    "UseLabels": false,
     "Labels": null
   }
 }


### PR DESCRIPTION
It turns out that if you use IngressClassName, having the nginx annotation at the same time will cause an error. This fixes it by defaulting to className only, but classname and annotations can be turned on and off or changed if needed through configuration parameters.

I also noticed that I had the start of a Labels implementation, so I finished that feature in a similar style.

#61 