### PR TITLE
Fix Check for Change in Hostname List

### DIFF
--- a/Services/CertChangeService.cs
+++ b/Services/CertChangeService.cs
@@ -1,0 +1,127 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using k8s.Models;
+using Microsoft.Extensions.Logging;
+
+namespace KCert.Services;
+
+[Service]
+public class CertChangeService
+{
+    private readonly ILogger<CertChangeService> _log;
+    private readonly K8sClient _k8s;
+    private readonly KCertClient _kcert;
+
+    private Task _runningTask = Task.CompletedTask;
+    private Task _nextTask = null;
+
+    public CertChangeService(ILogger<CertChangeService> log, K8sClient k8s, KCertClient kcert)
+    {
+        _log = log;
+        _k8s = k8s;
+        _kcert = kcert;
+    }
+
+    // Ensures that at least one whole check for changes is executed after every call to this function
+    // In otherwords:
+    // - If no check is currently running, it will kick off a check
+    // - If a check is already running, it will queue up another one to run after the current one completes
+    // - However, it will not queue up multiple checks
+    public void RunCheck()
+    {
+        lock(this)
+        {
+            if (_nextTask != null)
+            {
+                return;
+            }
+
+            _nextTask = CheckForChangesAsync(_runningTask);
+        }
+    }
+
+    private async Task CheckForChangesAsync(Task previous)
+    {
+        await previous;
+
+        lock(this)
+        {
+            _runningTask = _nextTask;
+            _nextTask = null;
+        }
+
+        // fetch all ingresses to figure out which certs need have which hosts
+        var nsLookup = new Dictionary<(string Namespace, string Name), HashSet<string>>();
+        await foreach (var (ns, name, hosts) in MergeAsync(GetIngressCertsAsync(), GetConfigMapCertsAsync()))
+        {
+            var key = (ns, name);
+            if (!nsLookup.TryGetValue(key, out var currHosts))
+            {
+                currHosts = new HashSet<string>();
+                nsLookup.Add(key, currHosts);
+            }
+
+            foreach (var h in hosts)
+            {
+                currHosts.Add(h);
+            }
+        }
+
+        foreach (var ((ns, name), hosts) in nsLookup)
+        {
+            _log.LogInformation("Handling cert {ns} - {name} hosts: {h}", ns, name, string.Join(",", hosts));
+            await _kcert.RenewIfNeededAsync(ns, name, hosts.ToArray(), CancellationToken.None);
+        }
+    }
+
+    private static async IAsyncEnumerable<T> MergeAsync<T>(params IAsyncEnumerable<T>[] enumerators)
+    {
+        foreach (var e in enumerators)
+        {
+            await foreach (var v in e)
+            {
+                yield return v;
+            }
+        }
+    }
+
+    private async IAsyncEnumerable<(string Namespace, string Name, IEnumerable<string> hosts)> GetIngressCertsAsync()
+    {
+        await foreach (var ing in _k8s.GetAllIngressesAsync())
+        {
+            _log.LogInformation("Processing ingress {ns}:{n}", ing.Namespace(), ing.Name());
+            foreach (var tls in ing?.Spec?.Tls ?? new List<V1IngressTLS>())
+            {
+                _log.LogInformation("Processing secret {s}", tls.SecretName);
+                yield return (ing.Namespace(), tls.SecretName, tls.Hosts);
+            }
+        }
+    }
+
+    private async IAsyncEnumerable<(string Namespace, string Name, IEnumerable<string> hosts)> GetConfigMapCertsAsync()
+    {
+        await foreach (var config in _k8s.GetAllConfigMapsAsync())
+        {
+            _log.LogInformation("Processing configmap {ns}:{n}", config.Namespace(), config.Name());
+            var ns = config.Namespace();
+            var name = config.Name();
+            
+            if (!config.Data.TryGetValue("hosts", out var hostList))
+            {
+                _log.LogError("ConfigMap {ns}-{n} does not have a hosts entry", ns, name);
+                continue;
+            }
+
+            var hosts = hostList.Split(',');
+            if (hosts.Length < 1)
+            {
+                _log.LogError("ConfigMap {ns}-{n} does not contain a list of hosts", ns, name);
+                continue;
+            }
+
+            yield return (ns, name, hosts);
+        }
+    }
+}

--- a/Services/IngressMonitorService.cs
+++ b/Services/IngressMonitorService.cs
@@ -14,22 +14,20 @@ namespace KCert.Services;
 public class IngressMonitorService : IHostedService
 {
     private readonly ILogger<IngressMonitorService> _log;
-    private readonly KCertClient _kcert;
     private readonly K8sClient _k8s;
     private readonly K8sWatchClient _watch;
-    private readonly CertClient _cert;
+    private readonly CertChangeService _certChange;
     private readonly KCertConfig _cfg;
     private readonly ExponentialBackoff _exp;
 
-    public IngressMonitorService(ILogger<IngressMonitorService> log, KCertClient kcert, K8sClient k8s, CertClient cert, KCertConfig cfg, ExponentialBackoff exp, K8sWatchClient watch)
+    public IngressMonitorService(ILogger<IngressMonitorService> log, K8sClient k8s, KCertConfig cfg, ExponentialBackoff exp, K8sWatchClient watch, CertChangeService certChange)
     {
         _log = log;
-        _kcert = kcert;
         _k8s = k8s;
-        _cert = cert;
         _cfg = cfg;
         _exp = exp;
         _watch = watch;
+        _certChange = certChange;
     }
 
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
@@ -56,43 +54,12 @@ public class IngressMonitorService : IHostedService
         await _watch.WatchIngressesAsync((t, i) => HandleIngressEventAsync(t, i, tok), tok);
     }
 
-    private async Task HandleIngressEventAsync(WatchEventType type, V1Ingress ingress, CancellationToken tok)
+    private Task HandleIngressEventAsync(WatchEventType type, V1Ingress ingress, CancellationToken tok)
     {
         try
         {
             _log.LogInformation("Ingress change event [{type}] for {ns}-{name}", type, ingress.Namespace(), ingress.Name());
-            if (type != WatchEventType.Added && type != WatchEventType.Modified)
-            {
-                return;
-            }
-
-            // fetch all ingresses to figure out which certs need have which hosts
-            var nsLookup = new Dictionary<(string Namespace, string Name), HashSet<string>>();
-            await foreach (var ing in _k8s.GetAllIngressesAsync())
-            {
-                _log.LogInformation("Processing ingress {ns}:{n}", ing.Namespace(), ing.Name());
-                foreach (var tls in ing?.Spec?.Tls ?? new List<V1IngressTLS>())
-                {
-                    _log.LogInformation("Processing secret {s}", tls.SecretName);
-                    var key = (ing.Namespace(), tls.SecretName);
-                    if (!nsLookup.TryGetValue(key, out var hosts))
-                    {
-                        hosts = new HashSet<string>();
-                        nsLookup.Add(key, hosts);
-                    }
-
-                    foreach (var h in tls.Hosts)
-                    {
-                        hosts.Add(h);
-                    }
-                }
-            }
-
-            foreach (var ((ns, name), hosts) in nsLookup)
-            {
-                _log.LogInformation("Handling cert {ns} - {name} hosts: {h}", ns, name, string.Join(",", hosts));
-                await _kcert.RenewIfNeededAsync(ns, name, hosts.ToArray(), tok);
-            }
+            _certChange.RunCheck();
         }
         catch (TaskCanceledException ex)
         {
@@ -102,5 +69,7 @@ public class IngressMonitorService : IHostedService
         {
             _log.LogError(ex, "Ingress watch event handler failed unexpectedly");
         }
+
+        return Task.CompletedTask;
     }
 }

--- a/Services/K8sClient.cs
+++ b/Services/K8sClient.cs
@@ -51,6 +51,22 @@ public class K8sClient
         while (tok != null);
     }
 
+    public async IAsyncEnumerable<V1ConfigMap> GetAllConfigMapsAsync()
+    {
+        var label = $"{K8sWatchClient.CertRequestKey}={K8sWatchClient.CertRequestValue}";
+        string tok = null;
+        do
+        {
+            var result = await _client.ListConfigMapForAllNamespacesAsync(labelSelector: label, continueParameter: tok);
+            tok = result.Continue();
+            foreach (var i in result.Items)
+            {
+                yield return i;
+            }
+        }
+        while (tok != null);
+    }
+
     public async Task<List<V1Secret>> GetManagedSecretsAsync()
     {
         var result = await _client.ListSecretForAllNamespacesAsync(fieldSelector: TlsTypeSelector, labelSelector: $"{CertLabelKey}={CertLabelValue}");

--- a/Services/K8sWatchClient.cs
+++ b/Services/K8sWatchClient.cs
@@ -14,8 +14,8 @@ namespace KCert.Services;
 [Service]
 public class K8sWatchClient
 {
-    private const string CertRequestKey = "kcert.dev/cert-request";
-    private const string CertRequestValue = "request";
+    public const string CertRequestKey = "kcert.dev/cert-request";
+    public const string CertRequestValue = "request";
     public const string IngressLabelKey = "kcert.dev/ingress";
     public const string IngressLabelValue = "managed";
 

--- a/Services/KCertClient.cs
+++ b/Services/KCertClient.cs
@@ -19,16 +19,37 @@ public class KCertClient
     private readonly KCertConfig _cfg;
     private readonly ILogger<KCertClient> _log;
     private readonly EmailClient _email;
-
+    private readonly CertClient _cert;
     private Task _running = Task.CompletedTask;
 
-    public KCertClient(K8sClient kube, KCertConfig cfg, RenewalHandler getCert, ILogger<KCertClient> log, EmailClient email)
+    public KCertClient(K8sClient kube, KCertConfig cfg, RenewalHandler getCert, ILogger<KCertClient> log, EmailClient email, CertClient cert)
     {
         _kube = kube;
         _cfg = cfg;
         _getCert = getCert;
         _log = log;
         _email = email;
+        _cert = cert;
+    }
+
+    public async Task RenewIfNeededAsync(string ns, string name, string[] hosts, CancellationToken tok)
+    {
+        var secret = await _kube.GetSecretAsync(ns, name);
+        tok.ThrowIfCancellationRequested();
+
+        if (secret != null)
+        {
+            var cert = _cert.GetCert(secret);
+            var certHosts = _cert.GetHosts(cert).ToHashSet();
+            if (hosts.Length == certHosts.Count && hosts.All(h => certHosts.Contains(h)))
+            {
+                // nothing to do, cert already has all the hosts it needs to have
+                _log.LogInformation("Certificate already has all the needed hosts configured");
+                return;
+            }
+        }
+
+        await StartRenewalProcessAsync(ns, name, hosts, tok);
     }
 
     // Ensure that no certs are renewed in parallel
@@ -111,27 +132,27 @@ public class KCertClient
 
     private V1IngressRule CreateRule(string host)
     {
-        return new V1IngressRule
+
+        var path = new V1HTTPIngressPath
+        {
+            Path = "/.well-known/acme-challenge/",
+            PathType = "Prefix",
+            Backend = new()
+            {
+                Service = new()
+                {
+                    Name = _cfg.KCertServiceName,
+                    Port = new(number: _cfg.KCertServicePort)
+                },
+            },
+        };
+
+        return new()
         {
             Host = host,
-            Http = new V1HTTPIngressRuleValue
+            Http = new()
             {
-                Paths = new List<V1HTTPIngressPath>()
-                    {
-                        new V1HTTPIngressPath
-                        {
-                            Path = "/.well-known/acme-challenge/",
-                            PathType = "Prefix",
-                            Backend = new V1IngressBackend
-                            {
-                                Service = new V1IngressServiceBackend
-                                {
-                                    Name = _cfg.KCertServiceName,
-                                    Port = new V1ServiceBackendPort(number: _cfg.KCertServicePort)
-                                },
-                            },
-                        },
-                    },
+                Paths = new List<V1HTTPIngressPath>() { path }
             },
         };
     }


### PR DESCRIPTION
The current if-statement only checks that new hostlist contains hosts in the cert's current host list. This misses the scenario of removing a host.

The fix is easy: Also check that the hostlist lengths are equal.

#64