### PR TITLE
Support setting the resource.request or resource.limit for kcert helm deployment

### DIFF
--- a/charts/kcert/Chart.yaml
+++ b/charts/kcert/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kcert
 description: Deploys KCert for issuing Let's Encrypt certificates 
-version: 1.0.6
+version: 1.0.7
 appVersion: 1.2.0
 maintainers:
 - name: Nabeel Sulieman

--- a/charts/kcert/templates/070-Deployment.yaml
+++ b/charts/kcert/templates/070-Deployment.yaml
@@ -31,6 +31,10 @@ spec:
           name: http
         - containerPort: 8080
           name: http-admin
+        {{- if .Values.resources }}
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+        {{- end }}
         env:
         - name: KCERT__NAMESPACE
           value: {{ .Release.Namespace | default "default" }}
@@ -73,6 +77,7 @@ spec:
         - name: "{{ $key }}"
           value: "{{ $value }}"
 {{- end }}
+
 
 
 

--- a/charts/kcert/values.yaml
+++ b/charts/kcert/values.yaml
@@ -29,5 +29,7 @@ names:
   service: kcert
   app: kcert
 
+resources: {}
+
 # Set this to false in order to generate a plain yaml template without the Helm custom labels
 forHelm: true


### PR DESCRIPTION
I tested on the GKE autopilot cluster, and it works fine with custom ingress controllers like Kong. 

However, If I cannot set a resource limit, the GKE autopilot cluster will use default 0.5 vCPU and 2 GiB Memory, this is unacceptable.

This PR will support setting the resource like this:

### How to Use:
```bash
--set resources.requests.cpu=200m,resources.requests.memory=256Mi,
```

```bash
--set resources.limits.cpu=512m,resources.limits.memory=512Mi
```
