### PR TITLE
Support multiple ingress classes

### DIFF
--- a/Services/K8sClient.cs
+++ b/Services/K8sClient.cs
@@ -19,7 +19,6 @@ public class K8sClient
     private const string CertLabelKey = "kcert.dev/secret";
     private const string CertLabelValue = "managed";
     public const string IngressLabelKey = "kcert.dev/ingress";
-    public const string IngressLabelValue = "managed";
     private const string TlsTypeSelector = "type=kubernetes.io/tls";
     public const string IngressClassNameLabelKey = "kcert.dev/ingressClassName";
 
@@ -38,11 +37,7 @@ public class K8sClient
 
     public async IAsyncEnumerable<V1Ingress> GetAllIngressesAsync()
     {
-        var label = $"{IngressLabelKey}={IngressLabelValue}";
-        if (_cfg.LabelByClassName)
-        {
-            label += $",{IngressClassNameLabelKey}={_cfg.ChallengeIngressClassName}";
-        }
+        var label = $"{IngressLabelKey}={_cfg.IngressLabelValue}";
 
         string tok = null;
         do

--- a/Services/K8sClient.cs
+++ b/Services/K8sClient.cs
@@ -21,6 +21,7 @@ public class K8sClient
     public const string IngressLabelKey = "kcert.dev/ingress";
     public const string IngressLabelValue = "managed";
     private const string TlsTypeSelector = "type=kubernetes.io/tls";
+    public const string IngressClassNameLabelKey = "kcert.dev/ingressClassName";
 
     private readonly KCertConfig _cfg;
 
@@ -38,6 +39,11 @@ public class K8sClient
     public async IAsyncEnumerable<V1Ingress> GetAllIngressesAsync()
     {
         var label = $"{IngressLabelKey}={IngressLabelValue}";
+        if (_cfg.LabelByClassName)
+        {
+            label += $",{IngressClassNameLabelKey}={_cfg.ChallengeIngressClassName}";
+        }
+
         string tok = null;
         do
         {

--- a/Services/K8sClient.cs
+++ b/Services/K8sClient.cs
@@ -20,8 +20,6 @@ public class K8sClient
     private const string CertLabelValue = "managed";
     public const string IngressLabelKey = "kcert.dev/ingress";
     private const string TlsTypeSelector = "type=kubernetes.io/tls";
-    public const string IngressClassNameLabelKey = "kcert.dev/ingressClassName";
-
     private readonly KCertConfig _cfg;
 
     private readonly ILogger<K8sClient> _log;

--- a/Services/K8sWatchClient.cs
+++ b/Services/K8sWatchClient.cs
@@ -17,7 +17,6 @@ public class K8sWatchClient
     public const string CertRequestKey = "kcert.dev/cert-request";
     public const string CertRequestValue = "request";
     public const string IngressLabelKey = "kcert.dev/ingress";
-    public const string IngressLabelValue = "managed";
     public const string IngressClassNameLabelKey = "kcert.dev/ingressClassName";
 
     private readonly KCertConfig _cfg;
@@ -35,12 +34,7 @@ public class K8sWatchClient
 
     public async Task WatchIngressesAsync(Func<WatchEventType, V1Ingress, Task> callback, CancellationToken tok)
     {
-        var label = $"{IngressLabelKey}={IngressLabelValue}";
-
-        if (_cfg.LabelByClassName)
-        {
-            label += $",{IngressClassNameLabelKey}={_cfg.ChallengeIngressClassName}";
-        }
+        var label = $"{IngressLabelKey}={_cfg.IngressLabelValue}";
 
         var watch = () => _client.NetworkingV1.ListIngressForAllNamespacesWithHttpMessagesAsync(watch: true, cancellationToken: tok, labelSelector: label);
         await WatchInLoopAsync(label, watch, callback);

--- a/Services/K8sWatchClient.cs
+++ b/Services/K8sWatchClient.cs
@@ -18,6 +18,7 @@ public class K8sWatchClient
     public const string CertRequestValue = "request";
     public const string IngressLabelKey = "kcert.dev/ingress";
     public const string IngressLabelValue = "managed";
+    public const string IngressClassNameLabelKey = "kcert.dev/ingressClassName";
 
     private readonly KCertConfig _cfg;
 
@@ -35,6 +36,12 @@ public class K8sWatchClient
     public async Task WatchIngressesAsync(Func<WatchEventType, V1Ingress, Task> callback, CancellationToken tok)
     {
         var label = $"{IngressLabelKey}={IngressLabelValue}";
+
+        if (_cfg.LabelByClassName)
+        {
+            label += $",{IngressClassNameLabelKey}={_cfg.ChallengeIngressClassName}";
+        }
+
         var watch = () => _client.NetworkingV1.ListIngressForAllNamespacesWithHttpMessagesAsync(watch: true, cancellationToken: tok, labelSelector: label);
         await WatchInLoopAsync(label, watch, callback);
     }

--- a/Services/K8sWatchClient.cs
+++ b/Services/K8sWatchClient.cs
@@ -17,7 +17,6 @@ public class K8sWatchClient
     public const string CertRequestKey = "kcert.dev/cert-request";
     public const string CertRequestValue = "request";
     public const string IngressLabelKey = "kcert.dev/ingress";
-    public const string IngressClassNameLabelKey = "kcert.dev/ingressClassName";
 
     private readonly KCertConfig _cfg;
 

--- a/Services/KCertClient.cs
+++ b/Services/KCertClient.cs
@@ -188,7 +188,7 @@ public class KCertClient
     
     private async Task<bool> IsIngressPropagated(V1Ingress kcertIngress)
     {
-        var ingress = await _kube.GetIngressAsync(kcertIngress.Name(), kcertIngress.Namespace());
+        var ingress = await _kube.GetIngressAsync(kcertIngress.Namespace(), kcertIngress.Name());
         
         var isIngressPropagated = ingress.Status.LoadBalancer.Ingress?.Any() ?? false;
         return isIngressPropagated;

--- a/Services/KCertConfig.cs
+++ b/Services/KCertConfig.cs
@@ -57,6 +57,8 @@ public class KCertConfig
     public string SmtpUser => GetString("Smtp:User");
     public string SmtpPass => GetString("Smtp:Pass");
 
+    public bool LabelByClassName => GetBool("ChallengeIngress:LabelByClassName");
+
     public object AllConfigs => new
     {
         KCert = new

--- a/Services/KCertConfig.cs
+++ b/Services/KCertConfig.cs
@@ -57,7 +57,7 @@ public class KCertConfig
     public string SmtpUser => GetString("Smtp:User");
     public string SmtpPass => GetString("Smtp:Pass");
 
-    public bool IngressLabelValue => GetString("ChallengeIngress:IngressLabelValue");
+    public string IngressLabelValue => GetString("ChallengeIngress:IngressLabelValue");
 
     public object AllConfigs => new
     {

--- a/Services/KCertConfig.cs
+++ b/Services/KCertConfig.cs
@@ -57,7 +57,7 @@ public class KCertConfig
     public string SmtpUser => GetString("Smtp:User");
     public string SmtpPass => GetString("Smtp:Pass");
 
-    public bool LabelByClassName => GetBool("ChallengeIngress:LabelByClassName");
+    public bool IngressLabelValue => GetString("ChallengeIngress:IngressLabelValue");
 
     public object AllConfigs => new
     {

--- a/appsettings.json
+++ b/appsettings.json
@@ -36,7 +36,7 @@
     "Annotations": {
       "kubernetes.io/ingress.class": "nginx"
     },
-    "LabelByClassName": false,
+    "IngressLabelValue": "managed",
     "UseLabels": false,
     "Labels": null,
     "MaxPropagationWaitTimeSeconds": 300,

--- a/appsettings.json
+++ b/appsettings.json
@@ -8,7 +8,7 @@
           "Indented": true
         }
       }
-    } 
+    }
   },
   "KCert": {
     "Namespace": "kcert",
@@ -36,6 +36,7 @@
     "Annotations": {
       "kubernetes.io/ingress.class": "nginx"
     },
+    "LabelByClassName": false,
     "UseLabels": false,
     "Labels": null,
     "MaxPropagationWaitTimeSeconds": 300,

--- a/charts/kcert/templates/020-ServiceAccount.yaml
+++ b/charts/kcert/templates/020-ServiceAccount.yaml
@@ -1,13 +1,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ required "names.serviceAccount is required" .Values.names.serviceAccount }}
+  name: {{ include "kcert.fullname" . }}
   namespace: {{ .Release.Namespace | default "default" }}
 {{- if .Values.forHelm }}
   labels:
-    app.kubernetes.io/name: {{ .Chart.Name }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "kcert.labels" . | nindent 4 }}
 {{- end }}

--- a/charts/kcert/templates/030-ClusterRole.yaml
+++ b/charts/kcert/templates/030-ClusterRole.yaml
@@ -1,14 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ required "names.clusterRole is required" .Values.names.clusterRole }}
+  name: {{ include "kcert.fullname" . }}
 {{- if .Values.forHelm }}
   labels:
-    app.kubernetes.io/name: {{ .Chart.Name }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "kcert.labels" . | nindent 4 }}
 {{- end }}
 rules:
 - apiGroups: [""]

--- a/charts/kcert/templates/040-ClusterRoleBinding.yaml
+++ b/charts/kcert/templates/040-ClusterRoleBinding.yaml
@@ -1,20 +1,16 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ required "names.clusterRoleBinding is required" .Values.names.clusterRoleBinding }}
+  name: {{ include "kcert.fullname" . }}
 {{- if .Values.forHelm }}
   labels:
-    app.kubernetes.io/name: {{ .Chart.Name }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "kcert.labels" . | nindent 4 }}
 {{- end }}
 subjects:
 - kind: ServiceAccount
-  name: {{ required "names.serviceAccount is required" .Values.names.serviceAccount }}
+  name: {{ include "kcert.fullname" . }}
   namespace: {{ .Release.Namespace | default "kcert" }}
 roleRef:
   kind: ClusterRole
-  name: {{ required "names.clusterRole is required" .Values.names.clusterRole }}
+  name: {{ include "kcert.fullname" . }}
   apiGroup: rbac.authorization.k8s.io

--- a/charts/kcert/templates/050-Role.yaml
+++ b/charts/kcert/templates/050-Role.yaml
@@ -1,15 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ required "names.role is required" .Values.names.role }}
+  name: {{ include "kcert.fullname" . }}
   namespace: {{ .Release.Namespace | default "default" }}
 {{- if .Values.forHelm }}
   labels:
-    app.kubernetes.io/name: {{ .Chart.Name }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "kcert.labels" . | nindent 4 }}
 {{- end }}
 rules:
 - apiGroups: ["networking.k8s.io"]

--- a/charts/kcert/templates/060-RoleBinding.yaml
+++ b/charts/kcert/templates/060-RoleBinding.yaml
@@ -1,21 +1,17 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ required "names.role is required" .Values.names.role }}
+  name: {{ include "kcert.fullname" . }}
   namespace: {{ .Release.Namespace | default "default" }}
 {{- if .Values.forHelm }}
   labels:
-    app.kubernetes.io/name: {{ .Chart.Name }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "kcert.labels" . | nindent 4 }}
 {{- end }}
 subjects:
 - kind: ServiceAccount
-  name: {{ required "names.serviceAccount is required" .Values.names.serviceAccount }}
+  name: {{ include "kcert.fullname" . }}
   namespace: {{ .Release.Namespace | default "default" }}
 roleRef:
   kind: Role
-  name: {{ required "names.role is required" .Values.names.role }}
+  name: {{ include "kcert.fullname" . }}
   apiGroup: rbac.authorization.k8s.io

--- a/charts/kcert/templates/065-Secret.yaml
+++ b/charts/kcert/templates/065-Secret.yaml
@@ -3,15 +3,11 @@ apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: {{ required "names.secret is required" .Values.names.secret }}
+  name: {{ include "kcert.fullname" . }}-smtp
   namespace: {{ .Release.Namespace | default "default" }}
 {{- if .Values.forHelm }}
   labels:
-    app.kubernetes.io/name: {{ .Chart.Name }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "kcert.labels" . | nindent 4 }}
 {{- end }}
 stringData:
     password: {{ required "smtp.pass is required" .Values.smtp.pass }}

--- a/charts/kcert/templates/070-Deployment.yaml
+++ b/charts/kcert/templates/070-Deployment.yaml
@@ -1,30 +1,32 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ required "names.deployment is required" .Values.names.deployment }}
+  name: {{ include "kcert.fullname" . }}
   namespace: {{ .Release.Namespace | default "default" }}
   labels:
-    app: {{ required "names.app is required" .Values.names.app }}
-{{- if .Values.forHelm }}
-    app.kubernetes.io/name: {{ .Chart.Name }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end }}
+    app: {{ include "kcert.fullname" . }}
+    {{- if .Values.forHelm }}
+    {{- include "kcert.labels" . | nindent 4 }}
+    {{- end }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ required "names.app is required" .Values.names.app }}
+      app: {{ include "kcert.fullname" . }}
+      {{- if .Values.forHelm }}
+      {{- include "kcert.selectorLabels" . | nindent 6 }}
+      {{- end }}
   template:
     metadata:
       labels:
-        app: {{ required "names.app is required" .Values.names.app }}
+        app: {{ include "kcert.fullname" . }}
+        {{- if .Values.forHelm }}
+        {{- include "kcert.selectorLabels" . | nindent 8 }}
+        {{- end }}
     spec:
-      serviceAccountName: {{ required "names.serviceAccount is required" .Values.names.serviceAccount }}
+      serviceAccountName: {{ include "kcert.fullname" . }}
       containers:
-      - name: kcert
+      - name: {{ include "kcert.fullname" . }}
         image: {{ required "kcertImage is required" .Values.kcertImage }}
         ports:
         - containerPort: 80
@@ -55,7 +57,7 @@ spec:
         - name: SMTP__PASS
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.names.secret }}
+              name: {{ include "kcert.fullname" . }}-smtp
               key: password
 {{- end }}
 {{- if .Values.acmeKey.secretName }}

--- a/charts/kcert/templates/080-Service.yaml
+++ b/charts/kcert/templates/080-Service.yaml
@@ -1,17 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ required "names.service is required" .Values.names.service }}
+  name: {{ include "kcert.fullname" . }}
   namespace: {{ .Release.Namespace | default "default" }}
   labels:
-    app: kcert
-{{- if .Values.forHelm }}
-    app.kubernetes.io/name: {{ .Chart.Name }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end }}
+    app: {{ include "kcert.fullname" . }}
+    {{- if .Values.forHelm }}
+    {{- include "kcert.labels" . | nindent 4 }}
+    {{- end }}
 spec:
   ports:
     - name: http
@@ -23,4 +19,7 @@ spec:
       port: 8080
       targetPort: 8080
   selector:
-    app: {{ required "names.app is required" .Values.names.app }}
+    app: {{ include "kcert.fullname" . }}
+    {{- if .Values.forHelm }}
+    {{- include "kcert.selectorLabels" . | nindent 4 }}
+    {{- end }}

--- a/charts/kcert/templates/NOTES.txt
+++ b/charts/kcert/templates/NOTES.txt
@@ -1,4 +1,4 @@
 Congratulations! kcert should now be setup and running in your cluster.
 
-You can check out the dashboard by running `kubectl -n {{ .Release.Namespace | default "default" }} port-forward svc/{{ .Values.names.service }} 8080`
+You can check out the dashboard by running `kubectl -n {{ .Release.Namespace | default "default" }} port-forward svc/{{ include "kcert.fullname" . }} 8080`
 and then opening http://localhost:8080 in your browser.

--- a/charts/kcert/templates/_helpers.tpl
+++ b/charts/kcert/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kcert.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kcert.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kcert.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kcert.labels" -}}
+helm.sh/chart: {{ include "kcert.chart" . }}
+{{ include "kcert.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+
+{{/*
+Selector labels
+*/}}
+{{- define "kcert.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kcert.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/kcert/values.yaml
+++ b/charts/kcert/values.yaml
@@ -18,16 +18,5 @@ smtp:
   user: null
   pass: null
 
-names:
-  serviceAccount: kcert
-  clusterRole: kcert
-  clusterRoleBinding: kcert
-  role: kcert
-  roleBinding: kcert
-  secret: kcert-smtp
-  deployment: kcert
-  service: kcert
-  app: kcert
-
 # Set this to false in order to generate a plain yaml template without the Helm custom labels
 forHelm: true

--- a/charts/kcert/values.yaml
+++ b/charts/kcert/values.yaml
@@ -18,17 +18,6 @@ smtp:
   user: null
   pass: null
 
-names:
-  serviceAccount: kcert
-  clusterRole: kcert
-  clusterRoleBinding: kcert
-  role: kcert
-  roleBinding: kcert
-  secret: kcert-smtp
-  deployment: kcert
-  service: kcert
-  app: kcert
-
 resources: {}
 
 # Set this to false in order to generate a plain yaml template without the Helm custom labels


### PR DESCRIPTION
As we discussed in https://github.com/nabsul/kcert/discussions/96 , here are the changes for the feature.

### Bug fix `IsIngressPropagated` function wrong arguments
### Support multiple ingress classes
1. Remove the kcert helm name environment, cluster role binding will conflict when installing two kcert instance without set `names.clusterRoleBinding`, I suggest use `kcert.fullname` to reduce the configurable environment
2. Introduce a new environment `LabelByClassName` to tell kcert if needs to match by `kcert.dev/ingressClassName:{ingressClass}`

Please take a look when you have time, and help me bump the helm/docker version.