### PR TITLE
feat: make ingress PathType configurable via Helm env var, default to Prefix

### DIFF
--- a/Challenge/HttpChallengeProvider.cs
+++ b/Challenge/HttpChallengeProvider.cs
@@ -79,12 +79,17 @@ public class HttpChallengeProvider(K8sClient kube, KCertConfig cfg, ILogger<Http
         }
     }
 
+    private static string GetPathType()
+    {
+        return Environment.GetEnvironmentVariable("KCERT_PATH_TYPE") ?? "Prefix";
+    }
+
     private V1IngressRule CreateRule(string host)
     {
         var path = new V1HTTPIngressPath
         {
             Path = "/.well-known/acme-challenge/",
-            PathType = "Prefix",
+            PathType = GetPathType(),
             Backend = new()
             {
                 Service = new()

--- a/charts/kcert/Chart.yaml
+++ b/charts/kcert/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kcert
 description: Deploys KCert for issuing Let's Encrypt certificates 
-version: 1.0.7
+version: 1.0.8
 appVersion: 1.2.0
 maintainers:
 - name: Nabeel Sulieman

--- a/charts/kcert/templates/070-Deployment.yaml
+++ b/charts/kcert/templates/070-Deployment.yaml
@@ -55,6 +55,8 @@ spec:
         - name: ACME__EMAIL
           # Your email address for Let's Encrypt and email notifications
           value: {{ required "acmeEmail is required" .Values.acmeEmail }}
+        - name: KCERT_PATH_TYPE
+          value: {{ .Values.kcertPathType | default "Prefix" | quote }}
 {{- if .Values.smtp.secretName }}
         - name: SMTP__EMAILFROM
           valueFrom:

--- a/charts/kcert/values.yaml
+++ b/charts/kcert/values.yaml
@@ -39,3 +39,5 @@ resources: {}
 
 # Set this to false in order to generate a plain yaml template without the Helm custom labels
 forHelm: true
+
+kcertPathType: Prefix


### PR DESCRIPTION


### Description of Change

In recent versions of the NGINX Ingress Controller, [stricter validation rules have been introduced](https://kubernetes.github.io/ingress-nginx/faq/#validation-of-path) for `ingress.spec.rules.http.paths.path` when `pathType` is set to `Prefix` or `Exact`. These rules enforce that the `path` must:

* Begin with a `/`
* Only include alphanumeric characters, `/`, `_`, and `-`

If a path contains characters outside this set (e.g., for rewrite purposes), the `pathType` **must** be set to `ImplementationSpecific`. This validation is enforced by the Admission Webhook, and non-compliant ingress resources will be denied admission.

To ensure compatibility and prevent potential deployment failures, we are explicitly setting the default `pathType` to `Prefix` via an environment variable in the Helm chart. This default is safe for standard use cases where paths comply with the new restrictions.

For advanced use cases involving rewrites or non-standard characters in paths, users should explicitly override the `pathType` to `ImplementationSpecific`.
